### PR TITLE
Bumping tensorflow version and updating training and serving containers

### DIFF
--- a/code/requirements.txt
+++ b/code/requirements.txt
@@ -1,7 +1,5 @@
-sagemaker==2.16.3
-tensorflow-gpu==2.0
-tensorflow-gpu-estimator==2.1.0
-tensorflow-estimator==2.1.0
+tensorflow-gpu==2.3.1
+smdebug==0.9.3
 tensorflow-hub==0.10.0
 bert-for-tf2==0.14.7
 bert-tensorflow==1.0.4

--- a/code/train.py
+++ b/code/train.py
@@ -1,6 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: MIT-0
 import os
+os.environ["CUDA_VISIBLE_DEVICES"]="0"
 import argparse
 import json
 
@@ -16,7 +17,6 @@ import source.custom_layer as custlay
 import source.bert_preprocessing as berpre
 import source.postprocessing as postpro
 import source.sentence_preprocessing as senpre
-
 
 def main(args):
     #To-do: 
@@ -159,9 +159,10 @@ def main(args):
     # Note: This directory structure will need to be followed - see notes for the next section
     model_version = '1'
     export_dir = os.path.join(model_dir, 'model/', model_version)
-    tf.saved_model.save(obj=model,
-                        export_dir=export_dir)
-    
+    #tf.saved_model.save(obj=model,
+    #                    export_dir=export_dir)
+    #
+    model.save(export_dir)
     print("saving done")
     
     # Reporting test set performance

--- a/notebooks/ner-bert-keras-sagemaker.ipynb
+++ b/notebooks/ner-bert-keras-sagemaker.ipynb
@@ -63,10 +63,14 @@
     "PREFIX = 'graph-nerc-blog' #Feel free to change this\n",
     "DATA_FOLDER = 'tagged-data'\n",
     "\n",
+    "#Using default region, same as where this notebook is, change if needed\n",
+    "REGION = sagemaker_session.boto_region_name\n",
     "\n",
-    "print('Bucket:\\n{}'.format(BUCKET))\n",
     "INPUTS = 's3://{}/{}/{}/'.format(BUCKET,PREFIX,DATA_FOLDER)\n",
-    "display(INPUTS)"
+    "\n",
+    "print(\"Using region: {}\".format(REGION))\n",
+    "print('Bucket: {}'.format(BUCKET))\n",
+    "print(\"Using prefix : {}\".format(INPUTS))"
    ]
   },
   {
@@ -256,7 +260,7 @@
    "source": [
     "JOB_NAME = 'ner-bert-keras'\n",
     "INSTANCE_TYPE = 'ml.p3.2xlarge'\n",
-    "# INSTANCE_TYPE = \"local_gpu\""
+    "#INSTANCE_TYPE = \"local_gpu\""
    ]
   },
   {
@@ -294,6 +298,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#We'll be using the managed ECR image provided by AWS.\n",
+    "#Refer to https://github.com/aws/deep-learning-containers/blob/master/available_images.md for more details\n",
+    "\n",
+    "training_image_uri = f\"763104351884.dkr.ecr.{REGION}.amazonaws.com/tensorflow-training:2.3.1-gpu-py37-cu110-ubuntu18.04\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "hyperparameters = {'epochs': EPOCHS,\n",
     "                   'batch_size' : BATCH_SIZE,\n",
     "                   'max_sequence_length': MAX_SEQUENCE_LENGTH,\n",
@@ -306,8 +322,7 @@
     "                       source_dir='../code',\n",
     "                       entry_point='train.py', \n",
     "                       role=role,\n",
-    "                       framework_version='2.0',\n",
-    "                       py_version='py3',\n",
+    "                       image_uri=training_image_uri,\n",
     "                       hyperparameters=hyperparameters,\n",
     "                       instance_count=1,\n",
     "                       script_mode=True,\n",
@@ -335,7 +350,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "dt = datetime.now()\n",
@@ -355,7 +372,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "estimator.model_data"
+    "print(estimator.model_data)"
    ]
   },
   {
@@ -409,7 +426,6 @@
    "outputs": [],
    "source": [
     "MODEL_ARTEFACTS_S3_LOCATION = response.get('ModelArtifacts').get('S3ModelArtifacts')\n",
-    "# MODEL_ARTEFACTS_S3_LOCATION  = estimator.model_data\n",
     "\n",
     "INSTANCE_TYPE = \"ml.c5.4xlarge\""
    ]
@@ -429,9 +445,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "#We'll be using the managed ECR image provided by AWS.\n",
+    "#Refer to https://github.com/aws/deep-learning-containers/blob/master/available_images.md for more details\n",
+    "\n",
+    "inference_image_uri = f\"763104351884.dkr.ecr.{REGION}.amazonaws.com/tensorflow-inference:2.3.1-cpu-py37-ubuntu18.04\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "model = TensorFlowModel(entry_point='inference.py',\n",
     "                        source_dir='../code',\n",
-    "                        framework_version='2.0',\n",
+    "                        image_uri = inference_image_uri,\n",
     "                        role=role,\n",
     "                        model_data=MODEL_ARTEFACTS_S3_LOCATION,\n",
     "                        sagemaker_session=sagemaker_session,\n",


### PR DESCRIPTION
*Description of changes:*
Bumping TF version to 2.3.1 and using specific docker containers from (https://github.com/aws/deep-learning-containers/blob/master/available_images.md) for both training and inference to cover all necessary requirements.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
